### PR TITLE
fix: TEMS-68 disable reset button on form initial state

### DIFF
--- a/frontend/src/modules/accounts/components/AccountEditForm.tsx
+++ b/frontend/src/modules/accounts/components/AccountEditForm.tsx
@@ -10,6 +10,7 @@ import {
   FormLayout,
   Input,
 } from '../../../shared/components/form';
+import { FormikResetButton } from '../../../shared/components/form/FormikResetButton';
 import { useToast } from '../../../shared/hooks';
 import { nameValidator } from '../../../shared/schemas';
 import { useEdit } from '../hooks/useEdit';
@@ -178,7 +179,7 @@ export const AccountEditForm = ({
             </Field>
           </FormLayout>
           <Flex w='full' h='full'>
-            <Button type='reset'>Reset Inputs</Button>
+            <FormikResetButton />
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/modules/accounts/components/AccountRegisterForm.tsx
+++ b/frontend/src/modules/accounts/components/AccountRegisterForm.tsx
@@ -9,6 +9,7 @@ import {
   FormLayout,
   Input,
 } from '../../../shared/components/form';
+import { FormikResetButton } from '../../../shared/components/form/FormikResetButton';
 import { useToast } from '../../../shared/hooks';
 import { emailValidator, nameValidator } from '../../../shared/schemas';
 import { useRegister } from '../hooks/useRegister';
@@ -166,9 +167,7 @@ export const AccountRegisterForm = ({
             </Flex>
           </FormLayout>
           <Flex w='full' h='full'>
-            <Button type='reset' onClick={handleReset}>
-              Reset Inputs
-            </Button>
+            <FormikResetButton onClick={handleReset} />
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/modules/equipment/components/EquipmentAddForm.tsx
+++ b/frontend/src/modules/equipment/components/EquipmentAddForm.tsx
@@ -4,6 +4,7 @@ import { EquipmentDTO } from 'generated-api';
 import { useEffect } from 'react';
 import * as Yup from 'yup';
 import { FormLayout, Input, Select } from '../../../shared/components/form';
+import { FormikResetButton } from '../../../shared/components/form/FormikResetButton';
 import { useToast } from '../../../shared/hooks';
 import { useEquipment } from '../hooks/useEquipment';
 
@@ -135,7 +136,7 @@ export const EquipmentAddForm = ({ onComplete }: EquipmentAddFormProps) => {
             </Field>
           </FormLayout>
           <Flex w='full' h='full'>
-            <Button type='reset'>Reset Inputs</Button>
+            <FormikResetButton />
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/modules/equipment/components/EquipmentEditForm.tsx
+++ b/frontend/src/modules/equipment/components/EquipmentEditForm.tsx
@@ -4,6 +4,7 @@ import { EquipmentDTO } from 'generated-api';
 import { useEffect } from 'react';
 import * as Yup from 'yup';
 import { FormLayout, Input, Select } from '../../../shared/components/form';
+import { FormikResetButton } from '../../../shared/components/form/FormikResetButton';
 import { useToast } from '../../../shared/hooks';
 import { useEquipment } from '../hooks';
 
@@ -157,7 +158,7 @@ export const EquipmentEditForm = ({
             </FormLayout>
           </Form>
           <Flex w='full' h='full'>
-            <Button type='reset'>Reset Inputs</Button>
+            <FormikResetButton />
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/modules/organizers/components/OrganizerAddForm.tsx
+++ b/frontend/src/modules/organizers/components/OrganizerAddForm.tsx
@@ -4,6 +4,7 @@ import { OrganizerDTO, OrganizerDTOTypeEnum } from 'generated-api';
 import { useEffect } from 'react';
 import * as Yup from 'yup';
 import { FormLayout, Input, Select } from '../../../shared/components/form';
+import { FormikResetButton } from '../../../shared/components/form/FormikResetButton';
 import { useToast } from '../../../shared/hooks';
 import { useOrganizers } from '../hooks';
 
@@ -83,7 +84,7 @@ export const OrganizerAddForm = ({ onComplete }: OrganizerAddFormProps) => {
             </Field>
           </FormLayout>
           <Flex w='full' h='full'>
-            <Button type='reset'>Reset Inputs</Button>
+            <FormikResetButton />
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/modules/organizers/components/OrganizerEditForm.tsx
+++ b/frontend/src/modules/organizers/components/OrganizerEditForm.tsx
@@ -4,6 +4,7 @@ import { OrganizerDTO, OrganizerDTOTypeEnum } from 'generated-api';
 import { useEffect } from 'react';
 import * as Yup from 'yup';
 import { FormLayout, Input, Select } from '../../../shared/components/form';
+import { FormikResetButton } from '../../../shared/components/form/FormikResetButton';
 import { useToast } from '../../../shared/hooks';
 import { useOrganizers } from '../hooks';
 
@@ -98,7 +99,7 @@ export const OrganizerEditForm = ({
             </Field>
           </FormLayout>
           <Flex w='full' h='full'>
-            <Button type='reset'>Reset Inputs</Button>
+            <FormikResetButton />
             <Spacer />
             <Button
               variant='solid'

--- a/frontend/src/shared/components/form/FormikResetButton.tsx
+++ b/frontend/src/shared/components/form/FormikResetButton.tsx
@@ -1,0 +1,36 @@
+import { Button, ButtonProps } from '@chakra-ui/react';
+import { useFormikContext } from 'formik';
+import { useState, useEffect } from 'react';
+
+export const FormikResetButton = ({
+  children = 'Reset Inputs',
+  ...props
+}: ButtonProps) => {
+  const { initialValues, values } = useFormikContext();
+  const [isFormModified, setIsFormModified] = useState(false);
+
+  useEffect(() => {
+    const isChanged = (): boolean => {
+      return JSON.stringify(initialValues) !== JSON.stringify(values);
+    };
+
+    // Adapted from:
+    // https://stackoverflow.com/questions/73395387/javascript-comparing-if-2-objects-are-the-same
+    function handleChange() {
+      setIsFormModified(isChanged());
+    }
+
+    handleChange();
+  }, [initialValues, values]);
+
+  return (
+    <Button
+      type='reset'
+      disabled={!isFormModified}
+      _disabled={{ cursor: 'auto', opacity: 0.8 }}
+      {...props}
+    >
+      {children}
+    </Button>
+  );
+};


### PR DESCRIPTION
## Description

- Added a reusable `FormReset` button component to allow disabling of reset button on form initial state

## Checklist

- [x] Reviewed own code
- [ ] Commented on code that is hard to understand
- [ ] Implemented tests for the feature/bugfix
- [x] All **_Required_** GitHub status checks pass
- [x] The frontend and backend PR previews have been deployed

**Backend only**

- [ ] Added test data for new entity
- [ ] Generated the client api if there are new or deleted endpoints and/or DTOs
