### PR TITLE
feat(equipment): TEMS-7 TEMS-50 make equipment notes optional

### DIFF
--- a/frontend/src/modules/equipment/components/EquipmentAddForm.tsx
+++ b/frontend/src/modules/equipment/components/EquipmentAddForm.tsx
@@ -36,7 +36,7 @@ export const EquipmentAddForm = ({ onComplete }: EquipmentAddFormProps) => {
   const validationSchema = Yup.object({
     name: Yup.string().min(1).max(40).required('Required'),
     type: Yup.string().min(1).max(40).required('Required'),
-    notes: Yup.string().min(1).max(250).required('Required'),
+    notes: Yup.string().min(1).max(250),
   });
 
   useEffect(() => {
@@ -121,7 +121,7 @@ export const EquipmentAddForm = ({ onComplete }: EquipmentAddFormProps) => {
                 />
               )}
             </Field>
-            <Field name='notes' type='text' isRequired>
+            <Field name='notes' type='text'>
               {(fieldProps: FieldProps<string, EquipmentDTO>) => (
                 <Textarea
                   fieldProps={fieldProps}
@@ -129,7 +129,6 @@ export const EquipmentAddForm = ({ onComplete }: EquipmentAddFormProps) => {
                   label='Notes'
                   id='notes'
                   placeholder="Don't forget equipment bag"
-                  isRequired
                   data-cy='notes-input'
                 />
               )}

--- a/frontend/src/modules/equipment/components/EquipmentEditForm.tsx
+++ b/frontend/src/modules/equipment/components/EquipmentEditForm.tsx
@@ -142,7 +142,7 @@ export const EquipmentEditForm = ({
                   />
                 )}
               </Field>
-              <Field name='notes' type='text' isRequired>
+              <Field name='notes' type='text'>
                 {(fieldProps: FieldProps<string, EquipmentDTO>) => (
                   <Textarea
                     fieldProps={fieldProps}
@@ -150,7 +150,6 @@ export const EquipmentEditForm = ({
                     label='Notes'
                     id='notes'
                     placeholder="Don't forget equipment bag"
-                    isRequired
                     data-cy='notes-input'
                   />
                 )}


### PR DESCRIPTION
## Description

- Make equipment notes field optional

## Checklist

- [x] Reviewed own code
- [ ] Commented on code that is hard to understand
- [ ] Implemented tests for the feature/bugfix
- [x] All **_Required_** GitHub status checks pass
- [x] The frontend and backend PR previews have been deployed

**Backend only**

- [ ] Added test data for new entity
- [ ] Generated the client api if there are new or deleted endpoints and/or DTOs
