### PR TITLE
fix(sorted equipments/venues): use EventCreateDTO for getting sorted equipments and venues

### DIFF
--- a/backend/__tests__/integration/features/event.spec.ts
+++ b/backend/__tests__/integration/features/event.spec.ts
@@ -27,6 +27,10 @@ describe('event.spec.ts - Event Controller', () => {
   const eventApiPath = EventController.EVENT_API_PATH;
   const verifyEventCreationApiPath =
     eventApiPath + EventController.VERIFY_EVENT_CREATION_API_PATH;
+  const sortedEquipmentsApiPath =
+    eventApiPath + EventController.SORTED_EQUIPMENTS_API_PATH;
+  const sortedVenuesApiPath =
+    eventApiPath + EventController.SORTED_VENUES_API_PATH;
 
   const validEventCreateDTO: EventCreateDTO = {
     title: 'test',
@@ -222,12 +226,8 @@ describe('event.spec.ts - Event Controller', () => {
   describe('GET /sorted-equipments', () => {
     it('should get sorted equipments', async () => {
       const { body } = await requestWithStaff
-        .get(
-          eventApiPath +
-            '/' +
-            testEvent.id +
-            EventController.SORTED_EQUIPMENTS_API_PATH
-        )
+        .get(sortedEquipmentsApiPath)
+        .send(validEventCreateDTO)
         .expect(HttpStatus.OK);
 
       const { availableEquipments, unavailableEquipments } =
@@ -240,12 +240,8 @@ describe('event.spec.ts - Event Controller', () => {
   describe('GET /sorted-venues', () => {
     it('should get sorted venues', async () => {
       const { body } = await requestWithStaff
-        .get(
-          eventApiPath +
-            '/' +
-            testEvent.id +
-            EventController.SORTED_VENUES_API_PATH
-        )
+        .get(sortedVenuesApiPath)
+        .send(validEventCreateDTO)
         .expect(HttpStatus.OK);
 
       const { availableVenues, unavailableVenues } = body as SortedVenuesDTO;

--- a/backend/src/event/event.controller.ts
+++ b/backend/src/event/event.controller.ts
@@ -34,6 +34,20 @@ export class EventController {
     return this.eventService.getAllEvents();
   }
 
+  @Get(EventController.SORTED_EQUIPMENTS_API_PATH)
+  public async getSortedEquipments(
+    @Body() dto: EventCreateDTO
+  ): Promise<SortedEquipmentsDTO> {
+    return this.eventService.getSortedEquipments(dto.startTime, dto.endTime);
+  }
+
+  @Get(EventController.SORTED_VENUES_API_PATH)
+  public async getSortedVenues(
+    @Body() dto: EventCreateDTO
+  ): Promise<SortedVenuesDTO> {
+    return this.eventService.getSortedVenues(dto.startTime, dto.endTime);
+  }
+
   @Get(EventController.EVENT_ID_API_PATH)
   public async getEventById(@Param('id') id: string): Promise<EventDTO> {
     return this.eventService.getEventById(id);
@@ -63,25 +77,6 @@ export class EventController {
     @Req() { user }: RequestWithUser
   ): Promise<EventDTO> {
     return this.eventService.deleteEvent(id, user);
-  }
-
-  @Get(
-    EventController.EVENT_ID_API_PATH +
-      EventController.SORTED_EQUIPMENTS_API_PATH
-  )
-  public async getSortedEquipments(
-    @Param('id') id: string
-  ): Promise<SortedEquipmentsDTO> {
-    return this.eventService.getSortedEquipmentsByEventId(id);
-  }
-
-  @Get(
-    EventController.EVENT_ID_API_PATH + EventController.SORTED_VENUES_API_PATH
-  )
-  public async getSortedVenues(
-    @Param('id') id: string
-  ): Promise<SortedVenuesDTO> {
-    return this.eventService.getSortedVenuesByEventId(id);
   }
 
   @Post(EventController.VERIFY_EVENT_CREATION_API_PATH)

--- a/backend/src/event/event.service.ts
+++ b/backend/src/event/event.service.ts
@@ -247,38 +247,6 @@ export class EventService {
     return this.venueService.getSortedVenues(startTime, endTime);
   }
 
-  public async getSortedEquipmentsByEventId(
-    id: string
-  ): Promise<SortedEquipmentsDTO> {
-    try {
-      const event = await this.prismaService.event.findUniqueOrThrow({
-        where: { id },
-        select: { startTime: true, endTime: true },
-      });
-
-      return this.getSortedEquipments(event.startTime, event.endTime);
-    } catch (e) {
-      if (e instanceof NotFoundError) {
-        throw new NotFoundException();
-      }
-    }
-  }
-
-  public async getSortedVenuesByEventId(id: string): Promise<SortedVenuesDTO> {
-    try {
-      const event = await this.prismaService.event.findUniqueOrThrow({
-        where: { id },
-        select: { startTime: true, endTime: true },
-      });
-
-      return this.getSortedVenues(event.startTime, event.endTime);
-    } catch (e) {
-      if (e instanceof NotFoundError) {
-        throw new NotFoundException();
-      }
-    }
-  }
-
   public async verifyEventCreation(
     dto: EventCreateDTO
   ): Promise<ValidationErrorDTO> {

--- a/frontend/src/open-api/api/default-api.ts
+++ b/frontend/src/open-api/api/default-api.ts
@@ -1437,20 +1437,21 @@ export const DefaultApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {string} id
+     * @param {EventCreateDTO} eventCreateDTO
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getSortedEquipments: async (
-      id: string,
+      eventCreateDTO: EventCreateDTO,
       options: any = {}
     ): Promise<RequestArgs> => {
-      // verify required parameter 'id' is not null or undefined
-      assertParamExists('getSortedEquipments', 'id', id);
-      const localVarPath = `/api/v1/event/{id}/sorted-equipments`.replace(
-        `{${'id'}}`,
-        encodeURIComponent(String(id))
+      // verify required parameter 'eventCreateDTO' is not null or undefined
+      assertParamExists(
+        'getSortedEquipments',
+        'eventCreateDTO',
+        eventCreateDTO
       );
+      const localVarPath = `/api/v1/event/sorted-equipments`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1466,6 +1467,8 @@ export const DefaultApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any;
       const localVarQueryParameter = {} as any;
 
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -1474,6 +1477,11 @@ export const DefaultApiAxiosParamCreator = function (
         ...headersFromBaseOptions,
         ...options.headers,
       };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        eventCreateDTO,
+        localVarRequestOptions,
+        configuration
+      );
 
       return {
         url: toPathString(localVarUrlObj),
@@ -1482,20 +1490,17 @@ export const DefaultApiAxiosParamCreator = function (
     },
     /**
      *
-     * @param {string} id
+     * @param {EventCreateDTO} eventCreateDTO
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getSortedVenues: async (
-      id: string,
+      eventCreateDTO: EventCreateDTO,
       options: any = {}
     ): Promise<RequestArgs> => {
-      // verify required parameter 'id' is not null or undefined
-      assertParamExists('getSortedVenues', 'id', id);
-      const localVarPath = `/api/v1/event/{id}/sorted-venues`.replace(
-        `{${'id'}}`,
-        encodeURIComponent(String(id))
-      );
+      // verify required parameter 'eventCreateDTO' is not null or undefined
+      assertParamExists('getSortedVenues', 'eventCreateDTO', eventCreateDTO);
+      const localVarPath = `/api/v1/event/sorted-venues`;
       // use dummy base URL string because the URL constructor only accepts absolute URLs.
       const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
       let baseOptions;
@@ -1511,6 +1516,8 @@ export const DefaultApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any;
       const localVarQueryParameter = {} as any;
 
+      localVarHeaderParameter['Content-Type'] = 'application/json';
+
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {};
@@ -1519,6 +1526,11 @@ export const DefaultApiAxiosParamCreator = function (
         ...headersFromBaseOptions,
         ...options.headers,
       };
+      localVarRequestOptions.data = serializeDataIfNeeded(
+        eventCreateDTO,
+        localVarRequestOptions,
+        configuration
+      );
 
       return {
         url: toPathString(localVarUrlObj),
@@ -2925,12 +2937,12 @@ export const DefaultApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {string} id
+     * @param {EventCreateDTO} eventCreateDTO
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getSortedEquipments(
-      id: string,
+      eventCreateDTO: EventCreateDTO,
       options?: any
     ): Promise<
       (
@@ -2939,7 +2951,10 @@ export const DefaultApiFp = function (configuration?: Configuration) {
       ) => AxiosPromise<SortedEquipmentsDTO>
     > {
       const localVarAxiosArgs =
-        await localVarAxiosParamCreator.getSortedEquipments(id, options);
+        await localVarAxiosParamCreator.getSortedEquipments(
+          eventCreateDTO,
+          options
+        );
       return createRequestFunction(
         localVarAxiosArgs,
         globalAxios,
@@ -2949,12 +2964,12 @@ export const DefaultApiFp = function (configuration?: Configuration) {
     },
     /**
      *
-     * @param {string} id
+     * @param {EventCreateDTO} eventCreateDTO
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     async getSortedVenues(
-      id: string,
+      eventCreateDTO: EventCreateDTO,
       options?: any
     ): Promise<
       (
@@ -2963,7 +2978,7 @@ export const DefaultApiFp = function (configuration?: Configuration) {
       ) => AxiosPromise<SortedVenuesDTO>
     > {
       const localVarAxiosArgs = await localVarAxiosParamCreator.getSortedVenues(
-        id,
+        eventCreateDTO,
         options
       );
       return createRequestFunction(
@@ -3699,27 +3714,30 @@ export const DefaultApiFactory = function (
     },
     /**
      *
-     * @param {string} id
+     * @param {EventCreateDTO} eventCreateDTO
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
     getSortedEquipments(
-      id: string,
+      eventCreateDTO: EventCreateDTO,
       options?: any
     ): AxiosPromise<SortedEquipmentsDTO> {
       return localVarFp
-        .getSortedEquipments(id, options)
+        .getSortedEquipments(eventCreateDTO, options)
         .then((request) => request(axios, basePath));
     },
     /**
      *
-     * @param {string} id
+     * @param {EventCreateDTO} eventCreateDTO
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      */
-    getSortedVenues(id: string, options?: any): AxiosPromise<SortedVenuesDTO> {
+    getSortedVenues(
+      eventCreateDTO: EventCreateDTO,
+      options?: any
+    ): AxiosPromise<SortedVenuesDTO> {
       return localVarFp
-        .getSortedVenues(id, options)
+        .getSortedVenues(eventCreateDTO, options)
         .then((request) => request(axios, basePath));
     },
     /**
@@ -4310,27 +4328,27 @@ export class DefaultApi extends BaseAPI {
 
   /**
    *
-   * @param {string} id
+   * @param {EventCreateDTO} eventCreateDTO
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof DefaultApi
    */
-  public getSortedEquipments(id: string, options?: any) {
+  public getSortedEquipments(eventCreateDTO: EventCreateDTO, options?: any) {
     return DefaultApiFp(this.configuration)
-      .getSortedEquipments(id, options)
+      .getSortedEquipments(eventCreateDTO, options)
       .then((request) => request(this.axios, this.basePath));
   }
 
   /**
    *
-   * @param {string} id
+   * @param {EventCreateDTO} eventCreateDTO
    * @param {*} [options] Override http request option.
    * @throws {RequiredError}
    * @memberof DefaultApi
    */
-  public getSortedVenues(id: string, options?: any) {
+  public getSortedVenues(eventCreateDTO: EventCreateDTO, options?: any) {
     return DefaultApiFp(this.configuration)
-      .getSortedVenues(id, options)
+      .getSortedVenues(eventCreateDTO, options)
       .then((request) => request(this.axios, this.basePath));
   }
 

--- a/frontend/src/open-api/models/announcement-dto.ts
+++ b/frontend/src/open-api/models/announcement-dto.ts
@@ -29,6 +29,18 @@ export interface AnnouncementDTO {
    * @type {string}
    * @memberof AnnouncementDTO
    */
+  createdAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof AnnouncementDTO
+   */
+  updatedAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof AnnouncementDTO
+   */
   title: string;
   /**
    *

--- a/frontend/src/open-api/models/equipment-dto.ts
+++ b/frontend/src/open-api/models/equipment-dto.ts
@@ -31,6 +31,18 @@ export interface EquipmentDTO {
    * @type {string}
    * @memberof EquipmentDTO
    */
+  createdAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof EquipmentDTO
+   */
+  updatedAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof EquipmentDTO
+   */
   name: string;
   /**
    *

--- a/frontend/src/open-api/models/event-dto.ts
+++ b/frontend/src/open-api/models/event-dto.ts
@@ -34,6 +34,18 @@ export interface EventDTO {
    * @type {string}
    * @memberof EventDTO
    */
+  createdAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof EventDTO
+   */
+  updatedAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof EventDTO
+   */
   title: string;
   /**
    *

--- a/frontend/src/open-api/models/organizer-dto.ts
+++ b/frontend/src/open-api/models/organizer-dto.ts
@@ -29,6 +29,18 @@ export interface OrganizerDTO {
    * @type {string}
    * @memberof OrganizerDTO
    */
+  createdAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof OrganizerDTO
+   */
+  updatedAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof OrganizerDTO
+   */
   name: string;
   /**
    *

--- a/frontend/src/open-api/models/schedule-dto.ts
+++ b/frontend/src/open-api/models/schedule-dto.ts
@@ -29,6 +29,18 @@ export interface ScheduleDTO {
    * @type {string}
    * @memberof ScheduleDTO
    */
+  createdAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ScheduleDTO
+   */
+  updatedAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof ScheduleDTO
+   */
   availability: ScheduleDTOAvailabilityEnum;
   /**
    *

--- a/frontend/src/open-api/models/venue-dto.ts
+++ b/frontend/src/open-api/models/venue-dto.ts
@@ -31,6 +31,18 @@ export interface VenueDTO {
    * @type {string}
    * @memberof VenueDTO
    */
+  createdAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof VenueDTO
+   */
+  updatedAt?: string;
+  /**
+   *
+   * @type {string}
+   * @memberof VenueDTO
+   */
   name: string;
   /**
    *


### PR DESCRIPTION
## Description

- replaces id param with `EventCreateDTO` to get sorted equipments and venues

## Checklist

_First, create a draft pull request. Then mark the PR as ready for review when all necessary checkbox items has been completed_

- [x] Reviewed own code
- [x] Commented on code that is hard to understand
- [x] Implemented tests for the feature/bugfix
- [x] All **_Required_** GitHub status checks pass
- [x] The frontend and backend PR previews have been deployed

**Backend only**

- [ ] Added test data for new entity
- [x] Generated the client api if there are new or deleted endpoints and/or DTOs
