### PR TITLE
feat(events): update events UI and restrictions

### DIFF
--- a/frontend/src/modules/events/components/EquipmentSelect.tsx
+++ b/frontend/src/modules/events/components/EquipmentSelect.tsx
@@ -5,12 +5,16 @@ import {
   SortedEquipmentsDTO,
 } from 'generated-api';
 import { useEffect, useRef } from 'react';
-import { MultiValue } from 'react-select';
-import { SelectAsync } from '../../../shared/components/form/';
+import { MultiValue, Props } from 'react-select';
+import {
+  CustomSelectAsyncProps,
+  SelectAsync,
+} from '../../../shared/components/form/';
 import { isOption } from '../../../shared/helpers/';
 import { Option } from '../../../shared/types';
 import { useGetSortedEquipments } from '../hooks/';
 import { formLabelProps, groupBadgeStyles, groupStyles } from '../styles';
+import { AsyncProps } from 'react-select/async';
 
 export interface EquipmentOption extends Option {
   status: string;
@@ -23,9 +27,13 @@ export interface EquipmentGroupedOption {
 
 export interface EquipmentSelectProps {
   defaultValue?: EquipmentDTO[];
+  selectAsyncProps?: Props;
 }
 
-export const EquipmentSelect = ({ defaultValue }: EquipmentSelectProps) => {
+export const EquipmentSelect = ({
+  defaultValue,
+  selectAsyncProps,
+}: EquipmentSelectProps) => {
   const equipmentDefaultOptions = useRef<EquipmentGroupedOption[]>([]);
 
   const { schedule, getSortedEquipments } = useGetSortedEquipments();
@@ -173,7 +181,7 @@ export const EquipmentSelect = ({ defaultValue }: EquipmentSelectProps) => {
               name='equipmentIds'
               label='Equipment'
               id='equipmentIds'
-              placeholder='Type to search...'
+              placeholder='No equipment...'
               data-cy='equipment-select'
               formLabelProps={formLabelProps}
               fieldProps={fieldProps}
@@ -191,6 +199,10 @@ export const EquipmentSelect = ({ defaultValue }: EquipmentSelectProps) => {
               value={getFieldValue(fieldProps)}
               formatGroupLabel={formatGroupLabel}
               isOptionDisabled={isOptionDisabled}
+              isDisabled={selectAsyncProps?.isDisabled}
+              helperText={
+                selectAsyncProps?.isDisabled ? 'For Technical Staff only' : ''
+              }
             />
           )}
         </Field>

--- a/frontend/src/modules/events/components/EventStatus.tsx
+++ b/frontend/src/modules/events/components/EventStatus.tsx
@@ -1,0 +1,55 @@
+import { Tag, TagProps } from '@chakra-ui/react';
+import { EventDTOStatusEnum } from 'generated-api';
+
+export interface EventStatusProps {
+  status: EventDTOStatusEnum;
+}
+
+export const getEventStatusScheme = (status: EventDTOStatusEnum) => {
+  switch (status) {
+    case EventDTOStatusEnum.Pending:
+      return 'gray';
+    case EventDTOStatusEnum.Reserved:
+      return 'orange';
+    case EventDTOStatusEnum.Ongoing:
+      return 'green';
+    case EventDTOStatusEnum.Done:
+      return 'blue';
+    case EventDTOStatusEnum.Canceled:
+      return 'red';
+    case EventDTOStatusEnum.Postponed:
+      return 'pink';
+    default:
+      return 'gray';
+  }
+};
+
+export const getEventStatusColor = (status: EventDTOStatusEnum) => {
+  switch (status) {
+    case EventDTOStatusEnum.Pending:
+      return '#718096';
+    case EventDTOStatusEnum.Reserved:
+      return '#CBD5E0';
+    case EventDTOStatusEnum.Ongoing:
+      return '#68D391';
+    case EventDTOStatusEnum.Done:
+      return '#63B3ED';
+    case EventDTOStatusEnum.Canceled:
+      return '#FC8181';
+    case EventDTOStatusEnum.Postponed:
+      return '#FC8181';
+    default:
+      return '#718096';
+  }
+};
+
+export const EventStatus = ({
+  status,
+  ...props
+}: EventStatusProps & TagProps) => {
+  return (
+    <Tag colorScheme={getEventStatusScheme(status)} {...props}>
+      {status}
+    </Tag>
+  );
+};

--- a/frontend/src/modules/events/components/EventView.tsx
+++ b/frontend/src/modules/events/components/EventView.tsx
@@ -1,22 +1,37 @@
-import { Button, Center, Flex, Spacer, Spinner } from '@chakra-ui/react';
-import { EventDTO } from 'generated-api';
+import { Button, Center, Flex, Spacer, Spinner, Tag } from '@chakra-ui/react';
+import {
+  EventDTO,
+  EventDTOStatusEnum,
+  RegisterUserDTORolesEnum,
+} from 'generated-api';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
 import { FieldTableBody } from '../../../shared/components/table';
 import { ModalTable } from '../../../shared/components/table/FieldTable';
+import { isRoleUnauthorized } from '../../../shared/helpers';
+import { useGlobalStore } from '../../../shared/stores';
 import { useEvents } from '../hooks/';
+import { EventStatus } from './EventStatus';
 
 interface EventViewProps {
   id: string | null;
   onDelete: (eventDTO: EventDTO) => void;
   onEdit: (eventDTO: EventDTO) => void;
+  onApprove: (eventDTO: EventDTO) => void;
 }
 
-export const EventView = ({ id, onDelete, onEdit }: EventViewProps) => {
+export const EventView = ({
+  id,
+  onDelete,
+  onEdit,
+  onApprove,
+}: EventViewProps) => {
+  const { getUser } = useGlobalStore();
   const { getEventById } = useEvents();
 
   const [event, setEvent] = useState<EventDTO | null>(null);
   const [editActionIsLoading, setEditActionIsLoading] = useState(false);
+  const [approveActionIsLoading, setApproveActionIsLoading] = useState(false);
   const [deleteActionIsLoading, setDeleteActionIsLoading] = useState(false);
 
   useEffect(() => {
@@ -39,13 +54,64 @@ export const EventView = ({ id, onDelete, onEdit }: EventViewProps) => {
       setDeleteActionIsLoading(false);
     }
   };
-  
+
   const handleEdit = () => {
     setEditActionIsLoading(true);
     if (event) {
       onEdit(event);
       setDeleteActionIsLoading(false);
     }
+  };
+
+  const handleQuickApprove = () => {
+    setApproveActionIsLoading(true);
+    if (event) {
+      onApprove(event);
+      if (id !== null) {
+        getEventById.mutate(id);
+      }
+      setApproveActionIsLoading(false);
+    }
+  };
+
+  const checkUserOwnership = () => {
+    const user = getUser();
+
+    // allows Staff or Admins to update any event
+    if (
+      !!user &&
+      !isRoleUnauthorized(user, [
+        RegisterUserDTORolesEnum.Staff,
+        RegisterUserDTORolesEnum.Admin,
+      ])
+    ) {
+      return false;
+    }
+
+    const encodedByUser = event?.encodedBy;
+
+    return user?.id !== encodedByUser?.id;
+  };
+
+  const isStatusAndRolesInvalid = (): boolean => {
+    const user = getUser();
+
+    if (!event || !user) {
+      return false;
+    }
+
+    const areRolesInvalid = isRoleUnauthorized(user, [
+      RegisterUserDTORolesEnum.Staff,
+      RegisterUserDTORolesEnum.Admin,
+    ]);
+
+    const isStatusInvalid = [
+      EventDTOStatusEnum.Reserved,
+      EventDTOStatusEnum.Ongoing,
+      EventDTOStatusEnum.Done,
+    ].includes(event?.status);
+
+    return isStatusInvalid || areRolesInvalid;
   };
 
   if (getEventById.isLoading) {
@@ -74,7 +140,8 @@ export const EventView = ({ id, onDelete, onEdit }: EventViewProps) => {
               },
               {
                 label: 'Status',
-                value: event?.status,
+                value: <EventStatus status={event?.status} />,
+
                 type: 'text',
               },
               {
@@ -142,7 +209,7 @@ export const EventView = ({ id, onDelete, onEdit }: EventViewProps) => {
         )}
       </ModalTable>
 
-      <Flex w='full' h='full'>
+      <Flex w='full' h='full' hidden={checkUserOwnership()}>
         <Button
           variant='outline'
           color='errorColor'
@@ -156,6 +223,18 @@ export const EventView = ({ id, onDelete, onEdit }: EventViewProps) => {
           Delete Event
         </Button>
         <Spacer />
+        <Button
+          variant='ghost'
+          data-cy='approve-btn'
+          formNoValidate
+          isLoading={approveActionIsLoading}
+          loadingText='Approving...'
+          onClick={handleQuickApprove}
+          mr={2}
+          hidden={isStatusAndRolesInvalid()}
+        >
+          Approve Event
+        </Button>
         <Button
           variant='solid'
           data-cy='update-submit-btn'

--- a/frontend/src/modules/events/components/Events.tsx
+++ b/frontend/src/modules/events/components/Events.tsx
@@ -1,6 +1,6 @@
 import { ContentSection } from '../../../shared/components/content';
 import { MainLayout } from '../../../shared/components/layout';
-import { staffAuth } from '../../../shared/schemas';
+import { basicAuth } from '../../../shared/schemas';
 import { EventsCalendar } from './EventsCalendar';
 
 export const Events = () => {
@@ -13,4 +13,4 @@ export const Events = () => {
   );
 };
 
-Events.auth = staffAuth;
+Events.auth = basicAuth;

--- a/frontend/src/modules/events/components/EventsCalendar.tsx
+++ b/frontend/src/modules/events/components/EventsCalendar.tsx
@@ -239,7 +239,13 @@ export const EventsCalendar = ({
           slotMinTime='06:00'
           slotMaxTime='24:00'
           eventClick={handleEventClick}
-          eventDragStop={() => console.log('drag stopped')}
+          eventDragStop={() => {
+            toast({
+              status: 'error',
+              title: 'Quick updates through dragging is not supported',
+            });
+          }}
+          // eventMouseEnter={}
           eventStartEditable={false}
           eventDurationEditable={false}
           height='100%'

--- a/frontend/src/modules/index/components/Dashboard.tsx
+++ b/frontend/src/modules/index/components/Dashboard.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Center,
   Flex,
   FlexProps,
@@ -11,13 +10,13 @@ import {
   StatLabel,
   StatNumber,
   Tag,
-  Text,
+  Text
 } from '@chakra-ui/react';
 import {
   AnnouncementDTO,
   AnnouncementDTOViewAccessEnum,
   EventDTO,
-  EventDTOStatusEnum,
+  EventDTOStatusEnum
 } from 'generated-api';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
@@ -26,7 +25,7 @@ import { A11y, Autoplay, Navigation, Pagination, Scrollbar } from 'swiper';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import {
   ContentHeader,
-  ContentSection,
+  ContentSection
 } from '../../../shared/components/content';
 import { MainLayout } from '../../../shared/components/layout/MainLayout';
 import { basicAuth } from '../../../shared/schemas';
@@ -45,8 +44,9 @@ import {
   imgSample3,
   imgSample4,
   imgSample5,
-  imgSample6,
+  imgSample6
 } from '../../../assets';
+import { LinkButton } from '../../../shared/components/elements';
 import { brandSmallScrollbar } from '../../../styles/components';
 
 export const Dashboard = () => {
@@ -104,9 +104,12 @@ export const Dashboard = () => {
       <ContentHeader
         title='Dashboard'
         actions={
-          <Button variant='solid' data-cy='reserve-event-btn'>
-            Reserve Event
-          </Button>
+          <LinkButton
+            variant='solid'
+            label='Reserve Event'
+            route='/events/reserve'
+            data-cy='reserve-event-btn'
+          />
         }
       />
 

--- a/frontend/src/shared/components/form/SelectAsync.tsx
+++ b/frontend/src/shared/components/form/SelectAsync.tsx
@@ -13,7 +13,7 @@ import { GroupBase, StylesConfig, Theme } from 'react-select';
 import ReactSelectAsync, { AsyncProps } from 'react-select/async';
 import { ErrorTooltip } from './ErrorTooltip';
 
-interface CustomSelectAsyncProps {
+export interface CustomSelectAsyncProps {
   label?: string;
   tooltipLabel?: string;
   fieldProps: FieldProps;

--- a/frontend/src/shared/components/table/FieldTableBody.tsx
+++ b/frontend/src/shared/components/table/FieldTableBody.tsx
@@ -3,8 +3,8 @@ import { PasswordField } from './PasswordField';
 
 type TableDataType = {
   label: string | undefined | null;
-  value: string | undefined | null;
-  type: 'text' | 'textarea' | 'password' | undefined | null;
+  value: string | React.ReactNode | undefined | null;
+  type: 'text' | 'textarea' | 'password' | 'node' | undefined | null;
 };
 
 interface FieldTableBodyProps {
@@ -20,7 +20,7 @@ export const FieldTableBody = ({ data }: FieldTableBodyProps) => {
   const getComponentType = (data: TableDataType) => {
     const { label, type, value } = data;
 
-    if (type === 'textarea' && value) {
+    if (typeof value === 'string' && type === 'textarea' && value) {
       return (
         <>
           <Th
@@ -48,7 +48,7 @@ export const FieldTableBody = ({ data }: FieldTableBodyProps) => {
       );
     }
 
-    if (type === 'password' && value) {
+    if (typeof value === 'string' && type === 'password' && value) {
       return (
         <>
           <Th borderBottom='0px'>{label}</Th>
@@ -64,7 +64,7 @@ export const FieldTableBody = ({ data }: FieldTableBodyProps) => {
       <>
         <Th borderBottom='0px'>{label}</Th>
         <Td borderBottom='0px' minW={60}>
-          {value?.length === 0 ? 'None' : value}
+          {typeof value === 'string' && value?.length === 0 ? 'None' : value}
         </Td>
       </>
     );

--- a/frontend/src/styles/globals.scss
+++ b/frontend/src/styles/globals.scss
@@ -41,6 +41,10 @@
   color: black;
 }
 
+.fc-event:hover {
+  cursor: pointer;
+}
+
 .fc-list-day-side-text {
   color: black;
 }


### PR DESCRIPTION
## Description

- Add events status colors
- Add restrictions to Organizer accounts to only Update their own encoded events (Staff & Admins can override everything)
- Add `Quick Approve` feature for staff & admin accounts



## Checklist

_First, create a draft pull request. Then mark the PR as ready for review when all necessary checkbox items has been completed_

- [x] Reviewed own code
- [ ] Commented on code that is hard to understand
- [ ] Implemented tests for the feature/bugfix
- [x] All **_Required_** GitHub status checks pass
- [x] The frontend and backend PR previews have been deployed

**Backend only**

- [ ] Added test data for new entity
- [ ] Generated the client api if there are new or deleted endpoints and/or DTOs
